### PR TITLE
chore migrate gihub actions to Action Manager

### DIFF
--- a/.github/workflows/go-lint.yaml
+++ b/.github/workflows/go-lint.yaml
@@ -9,14 +9,14 @@ jobs:
   golangci-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: ContentSquare/actions-checkout@approved-v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: ContentSquare/actions-setup-go@approved-v5
         with:
           go-version-file: 'go.mod'
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v8
+        uses: contentsquare/golangci-golangci-lint-action@approved-v8
         with:
           version: v2.1.5

--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -9,10 +9,10 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: ContentSquare/actions-checkout@approved-v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: ContentSquare/actions-setup-go@approved-v5
         with:
           go-version-file: 'go.mod'
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,12 +16,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: ContentSquare/actions-checkout@approved-v6
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: ContentSquare/actions-setup-go@approved-v5
         with:
           go-version-file: 'go.mod'
 
@@ -31,15 +31,15 @@ jobs:
           sudo apt install -y gcc gcc-aarch64-linux-gnu musl build-essential
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: ContentSquare/docker-setup-qemu-action@approved-v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: ContentSquare/docker-setup-buildx-action@approved-v3
         with:
           platforms: linux/amd64,linux/arm64
 
       - name: Docker login
-        uses: docker/login-action@v4
+        uses: ContentSquare/docker-login-action@approved-v4
         with:
           username: ${{ secrets.docker_username }}
           password: ${{ secrets.docker_password  }}


### PR DESCRIPTION
# Description

Migrate all GitHub Actions workflow files across ContentSquare repositories to use the Actions Manager Fork-and-Approved-Tag security model.

All direct upstream action references (e.g. `actions/checkout@v4`) have been replaced with their ContentSquare-managed fork equivalents (e.g. `ContentSquare/actions-checkout@approved-v4`) using `platform_github/allowed-actions.yaml` as the source of truth.

## Motivation and Context

The [Actions Manager](https://github.com/ContentSquare/platform_github?tab=readme-ov-file#actions-manager-recommended) implements a Fork-and-Approved-Tag security model to prevent supply chain attacks. Using direct upstream action references bypasses this model and will be blocked by security controls in the future.

This change ensures all workflows use only ContentSquare-controlled forks with security-reviewed approved tags, providing:
- **Supply chain protection**: only ContentSquare-controlled forks are used
- **Approved tags only**: no raw upstream tags
- **Audit trail**: complete approval and usage history

## Breaking Changes

No breaking changes. The ContentSquare fork actions are functionally identical to their upstream counterparts — only the reference syntax changes.

Actions not present in `allowed-actions.yaml` (no approved fork available yet) were left unchanged.

## How Has This Been Tested?

See the following CI runs in this PR