### PR TITLE
chore: upgrade GitHub Actions to node24 runtime

### DIFF
--- a/.github/workflows/go-lint.yaml
+++ b/.github/workflows/go-lint.yaml
@@ -12,11 +12,11 @@ jobs:
       - uses: ContentSquare/actions-checkout@approved-v6
 
       - name: Set up Go
-        uses: ContentSquare/actions-setup-go@approved-v5
+        uses: ContentSquare/actions-setup-go@approved-v6
         with:
           go-version-file: 'go.mod'
 
       - name: golangci-lint
-        uses: contentsquare/golangci-golangci-lint-action@approved-v8
+        uses: ContentSquare/golangci-golangci-lint-action@approved-v9
         with:
           version: v2.1.5

--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -12,7 +12,7 @@ jobs:
       - uses: ContentSquare/actions-checkout@approved-v6
 
       - name: Set up Go
-        uses: ContentSquare/actions-setup-go@approved-v5
+        uses: ContentSquare/actions-setup-go@approved-v6
         with:
           go-version-file: 'go.mod'
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: ContentSquare/actions-setup-go@approved-v5
+        uses: ContentSquare/actions-setup-go@approved-v6
         with:
           go-version-file: 'go.mod'
 
@@ -31,10 +31,10 @@ jobs:
           sudo apt install -y gcc gcc-aarch64-linux-gnu musl build-essential
 
       - name: Set up QEMU
-        uses: ContentSquare/docker-setup-qemu-action@approved-v3
+        uses: ContentSquare/docker-setup-qemu-action@approved-v4
 
       - name: Set up Docker Buildx
-        uses: ContentSquare/docker-setup-buildx-action@approved-v3
+        uses: ContentSquare/docker-setup-buildx-action@approved-v4
         with:
           platforms: linux/amd64,linux/arm64
 


### PR DESCRIPTION

This PR upgrades GitHub Actions workflow steps to their node24-compatible versions.

Node.js 16/20 GitHub Actions runners are deprecated. All `uses:` references have been updated to the latest approved node24 versions from `allowed-actions.lock.yaml`.